### PR TITLE
feat: add hooks, researcher agent, template-library skill, and succes…

### DIFF
--- a/.github/agents/researcher.agent.md
+++ b/.github/agents/researcher.agent.md
@@ -1,0 +1,104 @@
+---
+name: researcher
+description: "Read-only codebase exploration specialist for the RPI workflow. Accepts a research scope, applies the four diagnostic lenses to classify each finding, and produces a structured findings table for handoff to @planner. Never writes, edits, or deletes files. Use when you need a thorough codebase map before planning begins."
+tools:
+  - read/readFile
+  - search/listDirectory
+  - search/fileSearch
+  - search/textSearch
+  - search/codebase
+  - todo
+handoffs:
+  - label: Create Implementation Plan
+    agent: planner
+    prompt: Create a phased implementation plan based on the research findings above.
+    send: false
+---
+
+You are a codebase research specialist. Your job is to thoroughly explore the workspace, apply the four diagnostic lenses to classify every finding, and produce a structured report for handoff to `@planner`. You never write, edit, or delete any file. You never suggest implementation approaches — that is the planner's job.
+
+---
+
+## Procedure
+
+### Step 0 — Clarify scope
+
+1. Confirm the `research_scope` from the user's request (a directory, file pattern, or question).
+2. If the scope is absent or ambiguous, ask: "What is the research scope — a directory, file pattern, or specific question?"
+3. Do not proceed until the scope is unambiguous.
+
+---
+
+### Step 1 — Map the workspace
+
+1. List all top-level directories and note each one's purpose.
+2. Within the declared scope, list all relevant files and their line counts.
+3. Identify any existing related artifacts (instructions, prompts, hooks, agents, skills) that the scope touches.
+
+---
+
+### Step 2 — Read relevant files
+
+1. For each file identified in Step 1 that is relevant to the scope, read the complete file.
+2. Extract: what the file does, what it depends on, constraints it enforces, and conventions it follows.
+3. Note any gaps, inconsistencies, or quality issues.
+
+---
+
+### Step 3 — Apply the four diagnostic lenses
+
+Load and apply [feedback-lenses.instructions.md](../instructions/feedback-lenses.instructions.md).
+
+For each finding, assign **exactly one** lens:
+
+| Lens | Classification criterion | Target surface |
+|------|--------------------------|----------------|
+| 1 — Recurring Correction | Pattern appears in ≥ 2 sessions or locations | `copilot-instructions.md` rule |
+| 2 — Domain Vocabulary | Project-specific term used inconsistently or undefined | `*.instructions.md` with `applyTo` |
+| 3 — Workflow Friction | A repeated multi-step pattern that could be a slash command or agent | `*.prompt.md` or `*.agent.md` |
+| 4 — Quality Guardrail | A tool-call risk that should be blocked or gated | Hook (PreToolUse) |
+
+If a finding does not match any lens, classify it as `General` and include it in the Open Questions section.
+
+---
+
+### Step 4 — Produce the handoff report
+
+Produce all four sections below. Include every section, even if it has no rows (write "None found").
+
+---
+
+## File Index
+
+| File | Purpose | Lines | Relevant to scope? |
+|------|---------|-------|-------------------|
+| ... | | | |
+
+## Findings
+
+| File | Line | Finding | Relevance | Lens |
+|------|------|---------|-----------|------|
+| ... | | | High/Med/Low | 1–4 or General |
+
+## Open Questions
+
+List any ambiguities or gaps that the planner must resolve before creating a plan. If none, write "None found."
+
+## Handoff to Planner
+
+Paste **only** the Findings table here. No prose. This is the payload `@planner` consumes.
+
+| File | Line | Finding | Relevance | Lens |
+|------|------|---------|-----------|------|
+| ... | | | | |
+
+---
+
+## Rules
+
+- Read-only. Never write, edit, or delete any file during research.
+- Cite exact `file:line` references for every finding.
+- Assign exactly one lens per finding. If ambiguous, use the lowest-numbered matching lens.
+- Do not suggest implementation approaches or surface choices — classify only.
+- If the scope is too broad to complete in one pass, state the sub-scope covered and what remains.
+- If a file is empty or inaccessible, note it in Open Questions — do not skip silently.

--- a/.github/hooks/post-compact.json
+++ b/.github/hooks/post-compact.json
@@ -1,0 +1,10 @@
+{
+    "hooks": {
+        "PostCompact": [
+            {
+                "type": "command",
+                "command": "python .github/hooks/post-compact.py"
+            }
+        ]
+    }
+}

--- a/.github/hooks/post-compact.py
+++ b/.github/hooks/post-compact.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# post-compact.py — re-inject critical rules into context after compression
+
+import json
+import sys
+from pathlib import Path
+
+INSTRUCTIONS_PATH = Path(".github/copilot-instructions.md")
+PRIORITY_MARKER = "# PRIORITY: HIGH"
+MAX_CHARS = 800  # Conservative ceiling ≈ 200 tokens
+MAX_RULES = 5
+FALLBACK_MESSAGE = (
+    "IMPORTANT: Your context was just compressed. "
+    "Review .github/copilot-instructions.md before proceeding — "
+    "it contains the project's essential coding rules and conventions."
+)
+
+
+def extract_priority_lines(path: Path) -> list[str]:
+    """Return up to MAX_RULES lines from path that contain PRIORITY_MARKER."""
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+
+    priority_lines = [line.rstrip() for line in lines if PRIORITY_MARKER in line]
+    return priority_lines[:MAX_RULES]
+
+
+def build_context(priority_lines: list[str]) -> str:
+    """Build the additionalContext string, truncated to MAX_CHARS."""
+    if not priority_lines:
+        return FALLBACK_MESSAGE
+
+    header = "Critical project rules (re-injected after compaction):"
+    body = "\n".join(f"- {line.replace(PRIORITY_MARKER, '').strip()}" for line in priority_lines)
+    full = f"{header}\n{body}"
+
+    # Truncate to MAX_CHARS if needed (rare, but safety-net)
+    if len(full) > MAX_CHARS:
+        full = full[:MAX_CHARS].rsplit("\n", 1)[0] + "\n[truncated — see copilot-instructions.md]"
+
+    return full
+
+
+def main() -> None:
+    # Read stdin — PostCompact payload; we don't assert specific fields
+    try:
+        raw = sys.stdin.read()
+        _ = json.loads(raw) if raw.strip() else {}
+    except Exception:
+        pass  # Graceful degradation — stdin format doesn't affect injection
+
+    priority_lines = extract_priority_lines(INSTRUCTIONS_PATH)
+    additional_context = build_context(priority_lines)
+
+    output = {"additionalContext": additional_context}
+    print(json.dumps(output))
+    sys.exit(0)  # Always exit 0 — a failed PostCompact degrades quality but must not block
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/hooks/pre-compact.json
+++ b/.github/hooks/pre-compact.json
@@ -1,0 +1,10 @@
+{
+    "hooks": {
+        "PreCompact": [
+            {
+                "type": "command",
+                "command": "python .github/hooks/pre-compact.py"
+            }
+        ]
+    }
+}

--- a/.github/hooks/pre-compact.py
+++ b/.github/hooks/pre-compact.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# pre-compact.py — export full context snapshot to sessions/precompact/ before compression
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def main() -> None:
+    # Read the full stdin payload without asserting specific fields
+    raw = sys.stdin.read()
+    try:
+        payload = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError:
+        # Malformed stdin — write the raw string wrapped in a JSON object
+        payload = {"raw": raw}
+
+    # Derive session_id from payload or fall back to a timestamp-based ID
+    session_id = payload.get("session_id") or f"session-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%S')}"
+
+    # Build a timestamped filename — idempotent across multiple compressions per session
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    dest_dir = Path("sessions") / "precompact"
+    filename = dest_dir / f"{session_id}-{timestamp}.json"
+
+    # Create destination directory (exist_ok=True — safe if already present)
+    try:
+        dest_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        print(f"pre-compact: could not create {dest_dir}: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    # Write the snapshot — include the raw payload plus a capture timestamp
+    snapshot = {
+        "captured_at": f"{timestamp}",
+        "session_id": session_id,
+        "payload": payload,
+    }
+
+    try:
+        filename.write_text(json.dumps(snapshot, indent=2), encoding="utf-8")
+    except OSError as exc:
+        print(f"pre-compact: could not write snapshot to {filename}: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/hooks/session-start.json
+++ b/.github/hooks/session-start.json
@@ -1,0 +1,10 @@
+{
+    "hooks": {
+        "SessionStart": [
+            {
+                "type": "command",
+                "command": "python .github/hooks/session-start.py"
+            }
+        ]
+    }
+}

--- a/.github/hooks/session-start.py
+++ b/.github/hooks/session-start.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# session-start.py — inject project metadata (name, branch, commit, version) into session context
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+
+def run_git(args: list[str]) -> str:
+    """Run a git command and return stdout, or 'unknown' on any failure."""
+    try:
+        result = subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        return result.stdout.strip() if result.returncode == 0 else "unknown"
+    except Exception:
+        return "unknown"
+
+
+def read_package_version() -> str:
+    """Read version from package.json, or 'n/a' if absent or missing the field."""
+    try:
+        with open("package.json", encoding="utf-8") as f:
+            return json.load(f).get("version", "n/a")
+    except Exception:
+        return "n/a"
+
+
+def main() -> None:
+    # Read stdin (ignore contents — SessionStart payload may be empty)
+    try:
+        raw = sys.stdin.read()
+        _ = json.loads(raw) if raw.strip() else {}
+    except Exception:
+        pass  # Graceful degradation: continue even if stdin is malformed
+
+    # Collect orientation metadata — each field degrades individually on failure
+    project = os.path.basename(os.getcwd())
+    branch = run_git(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+    commit_sha = run_git(["git", "log", "-1", "--format=%H"])
+    version = read_package_version()
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # Build additionalContext — aim for ≤ 100 tokens (≈ 400 characters)
+    context_lines = [
+        f"project: {project}",
+        f"branch: {branch}",
+        f"commit: {commit_sha[:12] if commit_sha != 'unknown' else 'unknown'}",
+        f"version: {version}",
+        f"session_opened: {timestamp}",
+    ]
+    additional_context = "\n".join(context_lines)
+
+    output = {"additionalContext": additional_context}
+    print(json.dumps(output))
+    sys.exit(0)  # Always exit 0 — SessionStart must never block session opening
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/instructions/success-metrics.instructions.md
+++ b/.github/instructions/success-metrics.instructions.md
@@ -1,0 +1,43 @@
+---
+name: success-metrics
+description: Success metrics and anti-metrics for the Copilot feedback system. Apply when reviewing session quality, answering "Is the system improving?", or tracking feedback-loop health in session files.
+applyTo: "sessions/**"
+---
+
+# Success Metrics — Copilot Feedback System
+
+Rule: Evaluate feedback-system health using the five metrics below. Do not track
+vanity metrics. Report at least one metric value when asked "Is the system improving?"
+Reason: Qualitative statements about improvement are not actionable — these five
+metrics provide objective, trend-based answers using data collected automatically
+or with a single manual tally.
+
+## Five Metrics
+
+| Metric | Collection method | Healthy target | Anti-metric (do not track) |
+|--------|-------------------|----------------|---------------------------|
+| Corrections per session | Manual tally at session end | Trending ↓ over 4 weeks | Rule count (more rules ≠ better) |
+| Time to first correct output | Manual: note when agent first gets it right | Trending ↓ | Session duration |
+| Feedback debt backlog | Auto: count open items in `sessions/feedback-debt.md` | ≤ 5 open items | Items added per session |
+| Stale rule count | Auto: `/audit` output | 0 stale rules | Total rule count |
+| Hook failure rate | Auto: `sessions/metrics/sessions.jsonl` | 0 failures per week | Hook count |
+
+Rule: When the feedback-debt backlog reaches 5 open items, address the highest-priority
+(P0) item before adding new observations.
+Reason: An unbounded backlog signals the flywheel has stalled — the observation buffer
+is filling faster than it is being actioned.
+
+Rule: Report "corrections per session" as the primary improvement signal. Use the
+remaining four metrics as diagnostic signals only.
+Reason: Corrections per session is the only metric that directly measures whether the
+agent is learning from the feedback loop. All other metrics are leading or lagging
+indicators.
+
+## Collection Notes
+
+- **SessionEnd hook** auto-collects timestamps into `sessions/metrics/sessions.jsonl`.
+  This file may not exist until Feature #6 (SessionEnd hook) is implemented.
+- **Corrections per session** is the single manual tally — no form, no dashboard.
+  Note the count at session end; one number per session.
+- **Stale rule count** is auto-calculated by running `/audit` monthly.
+  Skip if `copilot-instructions.md` has fewer than 15 rules.

--- a/.github/prompts/compact.prompt.md
+++ b/.github/prompts/compact.prompt.md
@@ -1,7 +1,7 @@
 ---
 name: compact
 description: Capture session memory into five compact sections
-tools: [readFile, listDirectory]
+tools: [read, search]
 ---
 
 Create a compact session summary that preserves the session's reusable knowledge.

--- a/.github/skills/template-library/SKILL.md
+++ b/.github/skills/template-library/SKILL.md
@@ -1,0 +1,264 @@
+---
+name: template-library
+description: "Provides validated templates for all six GitHub Copilot integration surfaces. Use when creating a new rule, instruction file, prompt, agent, skill, or hook — the template encodes all required fields and exit-code contracts so nothing is missed. Triggers on: 'create rule', 'write instruction', 'new instruction', 'write prompt', 'create prompt', 'create agent', 'write agent', 'write skill', 'create skill', 'configure hook', 'new hook', 'scaffold', 'template'."
+metadata:
+  version: "1.0.0"
+---
+
+# Template Library
+
+Validated scaffold templates for all six GitHub Copilot knowledge surfaces.
+
+## When to Use
+
+Load this skill whenever you are creating or scaffolding one of the six surfaces. Apply the
+template **before** writing the artifact. Fill every `# REQUIRED` field. `# OPTIONAL` fields
+may be omitted if not applicable.
+
+| Surface | Template | Trigger phrases |
+|---------|----------|-----------------|
+| Global rule | T1 | "create rule", "add rule to copilot-instructions.md" |
+| Scoped instruction | T2 | "write instruction", "new instructions file" |
+| Prompt file | T3 | "write prompt", "create prompt", "slash command" |
+| Agent file | T4 | "create agent", "write agent", "new agent" |
+| Skill file | T5 | "write skill", "create skill", "new skill" |
+| Hook | T6 | "configure hook", "new hook", "write hook" |
+
+---
+
+## T1 — `copilot-instructions.md` Rule
+
+A single rule entry for the global always-on instruction file.
+
+```markdown
+Rule: <Imperative sentence stating what the agent should do.>
+Reason: <Why this rule was created — the triggering observation or recurring problem.>
+```
+
+**Validation checklist (apply before adding):**
+- [ ] Positive framing — says what TO do, not what to avoid
+- [ ] Includes `Reason:` clause with concrete justification
+- [ ] Specific — agent can apply without asking a follow-up question
+- [ ] Scoped correctly — belongs in global instructions (affects every file/session)
+- [ ] Non-contradictory — does not conflict with any existing rule
+- [ ] Tested — confirmed to produce intended behaviour in ≥ 1 session
+
+**Cap check:** `copilot-instructions.md` must stay ≤ 200 lines. If adding this rule would
+exceed the cap, split domain rules into a scoped `*.instructions.md` instead.
+
+---
+
+## T2 — `*.instructions.md` Scoped Instruction File
+
+A conditional instruction file that activates only for files matching `applyTo`.
+
+```markdown
+---                              # REQUIRED
+name: <slug>                     # REQUIRED — matches filename (minus .instructions.md)
+description: "<one sentence>"    # REQUIRED — what this instruction does and when it applies
+applyTo: "<glob>"                # REQUIRED — e.g. "sessions/**", "**/*.ts", "docs/**"
+---
+
+# <Title>
+
+<One-sentence summary of this instruction's domain.>
+
+Rule: <First rule statement.>
+Reason: <Why this rule was created.>
+
+Rule: <Second rule statement.>
+Reason: <Why this rule was created.>
+```
+
+**Required fields:** `name`, `description`, `applyTo`, at least one `Rule:` + `Reason:` pair.
+**Cap check:** ≤ 100 lines per file. If exceeded, create a second scoped file for the same domain.
+
+---
+
+## T3 — `*.prompt.md` Prompt File
+
+A slash-command prompt file placed in `.github/prompts/`.
+
+```markdown
+---                                      # REQUIRED
+description: "<Trigger description.>"   # REQUIRED — what invokes this prompt
+mode: ask | agent | edit                # REQUIRED — select one
+tools:                                  # OPTIONAL — omit for mode default
+  - read/readFile
+  - search/codebase
+model: <model-name>                     # OPTIONAL — omit to use user's selected model
+---
+
+## Instructions
+
+1. <First instruction step.>
+2. <Second instruction step.>
+
+## Output Format
+
+<Describe the expected output structure.>
+```
+
+**Required fields:** `description`, `mode`.
+**Cap check:** ≤ 150 lines body. If exceeded, extract reusable sections into a skill reference.
+**Mode guide:**
+- `ask` — read-only, conversational response; use for analysis, verification, audits
+- `agent` — autonomous with tools; use for multi-step workflows that need file access
+- `edit` — targeted file edits in focused context; use for code transformation tasks
+
+---
+
+## T4 — `*.agent.md` Agent File
+
+A custom agent placed in `.github/agents/`.
+
+```markdown
+---                                                    # REQUIRED
+name: <agent-name>                                     # REQUIRED — must match filename
+description: "<One-line role + specialisation.>"       # REQUIRED
+tools:                                                 # OPTIONAL — omit for all tools
+  - read/readFile                                      #   use category/name format
+  - search/listDirectory
+  - search/textSearch
+  - search/codebase
+handoffs:                                              # OPTIONAL — for RPI chains
+  - label: <Button text>
+    agent: <target-agent-name>
+    prompt: <Pre-filled message for the next agent.>
+    send: false
+user-invokable: true                                   # OPTIONAL — false = subagent only
+---
+
+You are a <role>. Your job is to <one sentence of core purpose>. You never <boundary>.
+
+## Procedure
+
+1. <Step 1 — concrete action.>
+2. <Step 2 — concrete action.>
+3. <Step 3 — concrete action.>
+
+## Output Format
+
+| Column A | Column B |
+|----------|----------|
+| ...      | ...      |
+
+## Rules
+
+- <Hard constraint 1.>
+- <Hard constraint 2.>
+- Never edit files (if read-only agent).
+```
+
+**Required fields:** `name`, `description`, persona statement, at least one procedure step,
+at least one rule.
+**Tool IDs:** Use `read/readFile`, `edit/editFiles`, `search/listDirectory`,
+`search/textSearch`, `search/codebase`, `search/fileSearch`, `execute/runInTerminal`, `todo`.
+**Cap check:** body ≤ 150 lines. If exceeded, the agent is doing too much — split.
+
+---
+
+## T5 — `SKILL.md` Skill File
+
+A skill file in `.github/skills/<skill-name>/SKILL.md`.
+
+```markdown
+---                                            # REQUIRED
+name: <skill-name>                             # REQUIRED — matches directory name
+description: "<Trigger-engineered summary.>"  # REQUIRED — include trigger phrases
+metadata:                                      # OPTIONAL
+  version: "1.0.0"
+---
+
+# <Skill Title>
+
+## When to Use
+
+<1-3 sentences: what problem this skill solves and when to invoke it.>
+
+## Procedure
+
+1. <Step 1.>
+2. <Step 2.>
+3. <Step 3.>
+
+## Output Format
+
+<Describe the expected output.>
+```
+
+**Required fields:** `name`, `description`, body with When to Use and Procedure sections.
+**Cap check:** ≤ 500 lines. If exceeded, split into core `SKILL.md` + `references/` documents.
+**Description tip:** Include trigger phrases in the description — the model uses these to
+activate the skill. Be specific: "apply four diagnostic lenses" beats "analyze sessions".
+
+---
+
+## T6 — Hook JSON + Python Script
+
+A lifecycle hook consisting of a JSON config and a Python script.
+
+**JSON config** (`.github/hooks/<event-kebab>.json`):
+
+```json
+{
+    "hooks": {
+        "<EventName>": [
+            {
+                "type": "command",
+                "command": "python .github/hooks/<script-name>.py"
+            }
+        ]
+    }
+}
+```
+
+Valid `<EventName>` values: `SessionStart`, `SessionEnd`, `PreToolUse`, `PostToolUse`,
+`PreCompact`, `PostCompact`, `Stop`, `Notification`.
+
+**Python script** (`.github/hooks/<script-name>.py`):
+
+```python
+#!/usr/bin/env python3                # REQUIRED — shebang line
+# <script-name>.py — <one-sentence description>  # REQUIRED — file header convention
+
+import json
+import sys
+# Add stdlib imports as needed (pathlib, subprocess, shutil, os, datetime)
+# NO third-party packages — stdlib only
+
+
+def main() -> None:
+    # === STOP HOOK ONLY: loop guard must be line 1 of main logic ===
+    # import os
+    # if os.environ.get("STOP_HOOK_ACTIVE") == "1":
+    #     sys.exit(0)
+
+    # Read stdin (hook payload)
+    raw = sys.stdin.read()
+    data = json.loads(raw) if raw.strip() else {}
+
+    # --- Hook logic here ---
+
+    # Exit code contract:           # REQUIRED
+    # sys.exit(0)  — success
+    # sys.exit(2)  — soft block (provide explanation on stderr; developer can override)
+    # sys.exit(1)  — hard fail (only for unrecoverable errors; avoid for safety hooks)
+
+    # Optional: output JSON for additionalContext injection
+    # print(json.dumps({"additionalContext": "<content>"}))
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+**Required fields:** shebang, file header comment (`# filename — description`), `main()`
+function, exit code contract.
+**Stop hook:** MUST include `stop_hook_active` loop guard as the first conditional check
+inside `main()`. Omitting it causes an infinite loop.
+**Execution budget:** < 500ms. Scripts calling `subprocess` must use `timeout=` parameter.
+**Context injection:** Only inject `additionalContext` from hooks that fire early in the
+session (SessionStart, PostCompact). Late hooks (Stop) should not inject context.


### PR DESCRIPTION
…s-metrics

Add three lifecycle hooks (SessionStart, PreCompact, PostCompact) to inject project metadata and manage context snapshots across session boundaries.

Add researcher.agent.md as the read-only first step in the RPI workflow, applying the four diagnostic lenses and handing findings to @planner.

Add template-library skill with validated scaffolds for all six Copilot integration surfaces (T1–T6).

Add success-metrics.instructions.md defining five measurable health indicators for the feedback flywheel.

Fix compact.prompt.md tool IDs (readFile/listDirectory → read/search).