### PR TITLE
docs(adr): add ADRs 0001-0015 from Arsanjani/Bustos book review

### DIFF
--- a/docs/adr/0001-level5-autonomous-maturity-placeholder.md
+++ b/docs/adr/0001-level5-autonomous-maturity-placeholder.md
@@ -1,0 +1,64 @@
+# ADR-0001: Level 5 Autonomous Maturity — Add Aspirational Placeholder to Adoption Roadmap
+
+Date: 2026-03-20
+Status: Proposed
+HITL Issue: [#9](https://github.com/pslits/copilot-session-feedback/issues/9)
+Decider: @pslits
+Risk Tier: low
+
+---
+
+## Context
+
+The adoption roadmap in [adoption-roadmap.instructions.md](../../.github/instructions/adoption-roadmap.instructions.md)
+covers Levels 2–4 of the GenAI Maturity Model. The book's Ch. 1 defines Level 5 as "Autonomous:
+self-improving, self-healing systems with minimal human oversight." The framework's Self-Improvement
+Flywheel is the mechanism that could eventually reach Level 5 — where hook scripts auto-detect
+recurring patterns and propose new rules without manual initiation.
+
+Currently, there is no reference to Level 5 anywhere in the framework. This creates a blind spot:
+a developer following the roadmap has no signal that the flywheel could be automated further, and no
+documented criteria for when to consider that step.
+
+The risk of adding a placeholder is minimal — it is a documentation-only change with no code or
+behaviour impact.
+
+---
+
+## Decision
+
+> **We decide to add a Level 5 "Aspirational" phase entry to the adoption roadmap describing the
+> conditions under which automated pattern detection could replace manual session analysis.**
+
+The entry should be clearly marked as aspirational/out-of-scope for the current VS Code-native
+constraint, while describing the capability threshold that would justify exploring it.
+
+---
+
+## Consequences
+
+### Positive
+- The roadmap is complete against the book's five-level maturity model.
+- Developers have a clear horizon to plan toward, rather than an abrupt "Ongoing" endpoint.
+- Prevents premature automation by naming the preconditions explicitly.
+
+### Negative / Risks
+- None anticipated. Documentation-only change.
+
+### Neutral
+- The Level 5 placeholder may surface questions about tool/plugin requirements outside VS Code.
+
+---
+
+## Follow-up Actions
+
+| Action | Owner | Due Date | Status |
+|---|---|---|---|
+| Add Level 5 entry to adoption-roadmap.instructions.md | @pslits | 2026-04-03 | Open |
+| Reference ADR-0001 in the roadmap file | @pslits | 2026-04-03 | Open |
+
+---
+
+## Outcome (complete after execution)
+
+_To be filled after the change is made._

--- a/docs/adr/0002-adaptation-spectrum-positioning.md
+++ b/docs/adr/0002-adaptation-spectrum-positioning.md
@@ -1,0 +1,63 @@
+# ADR-0002: Position Framework on the LLM Adaptation Spectrum
+
+Date: 2026-03-20
+Status: Proposed
+HITL Issue: [#10](https://github.com/pslits/copilot-session-feedback/issues/10)
+Decider: @pslits
+Risk Tier: low
+
+---
+
+## Context
+
+The book's Ch. 3 defines an LLM adaptation spectrum: in-context learning → RAG → fine-tuning. The
+framework's memory strategy — injecting rules into `copilot-instructions.md`, re-injecting via
+PostCompact hook, and using Copilot Memory — is in-context learning at inference time. This is a
+deliberate and correct choice given the VS Code-native constraint.
+
+However, nowhere in the framework is this named as such. The Memory Management catalogue entry
+does not declare "this is in-context learning, not RAG or fine-tuning." This makes the design
+rationale invisible: a reader cannot tell whether in-context learning was chosen or simply assumed.
+
+The ceiling of this choice is also undocumented: in-context learning is bounded by the context
+window. When `copilot-instructions.md` grows beyond ~3000 tokens, later rules are silently
+deprioritised. This is the known upper bound of the approach.
+
+---
+
+## Decision
+
+> **We decide to add an explicit paragraph to the Memory Management catalogue entry naming the
+> framework's adaptation mechanism as in-context learning and documenting the context-window
+> ceiling as a known constraint.**
+
+---
+
+## Consequences
+
+### Positive
+- Framework is explicitly positioned on the Ch. 3 spectrum.
+- The context-window ceiling is visible as a design constraint, not a surprise failure mode.
+- Makes RAG exclusion deliberate and documented rather than implicit.
+
+### Negative / Risks
+- None. Documentation-only change.
+
+### Neutral
+- May surface questions about whether context-window compression (PostCompact hook) counts as a
+  partial mitigation, which it does — and that relationship should be noted.
+
+---
+
+## Follow-up Actions
+
+| Action | Owner | Due Date | Status |
+|---|---|---|---|
+| Update Memory Management entry in patterns-catalogue.md | @pslits | 2026-04-03 | Open |
+| Cross-reference Ch. 3 of the book in the entry | @pslits | 2026-04-03 | Open |
+
+---
+
+## Outcome (complete after execution)
+
+_To be filled after the change is made._

--- a/docs/adr/0003-agent-input-output-schemas.md
+++ b/docs/adr/0003-agent-input-output-schemas.md
@@ -1,0 +1,73 @@
+# ADR-0003: Define Formal Input/Output Schemas for RPI Agent Chain
+
+Date: 2026-03-20
+Status: Proposed
+HITL Issue: [#11](https://github.com/pslits/copilot-session-feedback/issues/11)
+Decider: @pslits
+Risk Tier: medium
+
+---
+
+## Context
+
+The book's Ch. 4 (Agentic AI Architecture: Components and Interactions) stresses that agent
+contracts — defined input/output schemas — are non-negotiable for reliable multi-agent systems.
+Context loss at handoffs is the primary failure mode cited.
+
+The framework's three agents (`@researcher`, `@planner`, `@implementer`) currently have no formal
+contract table. Their agent files define roles and procedures but do not specify:
+- What exact artefacts each accepts as input
+- What exact artefacts each must produce before handing off
+- How handoff failure (missing output) is detected
+
+Without schemas, context loss at the `@researcher → @planner` handoff (summarisation too aggressive,
+losing file:line references) is the documented but unmitigated highest-probability failure mode.
+
+---
+
+## Decision
+
+> **We decide to add a formal contract section to each of the three RPI agent files, specifying
+> required input artefacts, required output artefacts, and the failure signal for an incomplete
+> handoff.**
+
+The contract table format will follow the book's Ch. 4 component interaction model:
+
+| Item | Format | Required |
+|---|---|---|
+| Input: session summary | Markdown with lens classifications | Yes |
+| Output: findings table | File:line references for each finding | Yes |
+
+---
+
+## Consequences
+
+### Positive
+- Handoff failures are detectable (missing required output → visible gap).
+- The `@researcher` output template can enforce file:line citation as a contract obligation.
+- Aligns the framework with Ch. 4 of the book.
+
+### Negative / Risks
+- Adding schema validation to agent files increases their length; must stay within token budget.
+- If the schema is too prescriptive, the agent becomes brittle to natural variation in session
+  content.
+
+### Neutral
+- The contract table may need to evolve as the agents mature; version it alongside the ADR.
+
+---
+
+## Follow-up Actions
+
+| Action | Owner | Due Date | Status |
+|---|---|---|---|
+| Add contract section to @researcher agent file | @pslits | 2026-04-03 | Open |
+| Add contract section to @planner agent file | @pslits | 2026-04-03 | Open |
+| Add contract section to @implementer agent file | @pslits | 2026-04-03 | Open |
+| Cross-reference ADR-0003 in each agent file | @pslits | 2026-04-03 | Open |
+
+---
+
+## Outcome (complete after execution)
+
+_To be filled after the change is made._

--- a/docs/adr/0004-a2a-informal-vs-formal-protocol.md
+++ b/docs/adr/0004-a2a-informal-vs-formal-protocol.md
@@ -1,0 +1,65 @@
+# ADR-0004: Document VS Code Handoffs as Informal A2A
+
+Date: 2026-03-20
+Status: Proposed
+HITL Issue: [#12](https://github.com/pslits/copilot-session-feedback/issues/12)
+Decider: @pslits
+Risk Tier: low
+
+---
+
+## Context
+
+The book's Ch. 4 and Ch. 5 treat Agent-to-Agent (A2A) communication as a formal protocol layer
+with message envelopes (sender, receiver, intent, payload, trace ID). The framework's Gulli #15
+(Inter-Agent Communication) is catalogued under Enterprise patterns and correctly excluded from
+the current single-developer context.
+
+However, the VS Code handoff mechanism used between `@researcher`, `@planner`, and `@implementer`
+IS informal A2A — agents pass accumulated context forward without a formal envelope. The catalogue
+currently does not acknowledge this distinction. A reader comparing the framework to the book's A2A
+definition may conclude the framework has no A2A at all, missing the implicit informal A2A that the
+RPI chain relies upon.
+
+---
+
+## Decision
+
+> **We decide to add a clarifying note to the Agentic Stack catalogue entry and the A2A (Gulli #15)
+> entry stating that VS Code agent handoffs constitute informal A2A — context forwarding without a
+> formal protocol envelope — and documenting when a formal A2A layer would be warranted.**
+
+The note will state: "The VS Code handoff mechanism is informal A2A: accumulated context is passed
+forward at the UI layer without a structured message envelope. Formal A2A (with trace IDs, sender/
+receiver fields, and idempotency) is warranted when agents operate across process boundaries or
+network hops — not applicable in this single-process VS Code context."
+
+---
+
+## Consequences
+
+### Positive
+- The framework's relationship to Ch. 4/5 A2A definitions is explicit.
+- Prevents confusion when comparing this framework to enterprise-grade A2A implementations.
+- Documents the upgrade path to formal A2A if the system scales.
+
+### Negative / Risks
+- None. Documentation-only change.
+
+### Neutral
+- May prompt a future ADR when the framework is extended to multi-machine or team use.
+
+---
+
+## Follow-up Actions
+
+| Action | Owner | Due Date | Status |
+|---|---|---|---|
+| Update Agentic Stack entry in patterns-catalogue.md | @pslits | 2026-04-03 | Open |
+| Update A2A (Gulli #15) entry with informal A2A note | @pslits | 2026-04-03 | Open |
+
+---
+
+## Outcome (complete after execution)
+
+_To be filled after the change is made._

--- a/docs/adr/0005-rpi-chain-fallback-strategy.md
+++ b/docs/adr/0005-rpi-chain-fallback-strategy.md
@@ -1,0 +1,75 @@
+# ADR-0005: Define Fallback Strategy for RPI Chain Agent Failure
+
+Date: 2026-03-20
+Status: Proposed
+HITL Issue: [#13](https://github.com/pslits/copilot-session-feedback/issues/13)
+Decider: @pslits
+Risk Tier: medium
+
+---
+
+## Context
+
+The book's Ch. 5 (Multi-Agent Coordination Patterns) emphasises that the Hierarchical Orchestrator
+is a single point of failure, and that orchestrator resilience must be explicitly designed. The same
+applies to pipeline topologies: if a mid-chain agent fails to produce the required handoff artefact,
+the downstream agents have no input and the pipeline stalls silently.
+
+The framework's design document acknowledges this in the Multi-Agent risk row ("context loss at
+handoff") but the only mitigation listed is "keep agent scopes narrow." No concrete fallback is
+defined for what happens when `@planner` fails to produce a phased plan, or when `@researcher`
+produces no codebase findings.
+
+The current situation means a developer gets no actionable guidance when the RPI chain breaks
+mid-execution — they must debug ad hoc rather than following a documented recovery path.
+
+---
+
+## Decision
+
+> **We decide to define and document a concrete fallback procedure for each RPI chain failure mode,
+> and to add the fallback logic to both the design document and the individual agent files.**
+
+Proposed fallbacks:
+1. **`@researcher` produces no findings:** Fall back to manual lens analysis using
+   the four-lenses instruction directly, skipping `@researcher`.
+2. **`@planner` produces no phased plan:** Fall back to direct `/implement` execution using the
+   researcher output as the specification, accepting reduced structure.
+3. **`@implementer` stalls mid-plan:** Re-invoke `@implementer` with the partial plan and the
+   step number to resume from.
+
+Each fallback is a human-actioned recovery, not an automated one, consistent with the system's
+HITL design.
+
+---
+
+## Consequences
+
+### Positive
+- Developers have a recovery path for each failure mode without ad-hoc debugging.
+- Aligns the framework with Ch. 5's resilience recommendations.
+- The fallback paths keep the pipeline useful even when individual agents underperform.
+
+### Negative / Risks
+- The documented fallbacks may encourage skipping agents ("I'll just fall back to manual").
+  Mitigation: frame fallbacks as last resort, not workflow shortcuts.
+
+### Neutral
+- Fallback paths are manually actioned; no automation required.
+
+---
+
+## Follow-up Actions
+
+| Action | Owner | Due Date | Status |
+|---|---|---|---|
+| Add fallback table to design document (Multi-Agent risks row) | @pslits | 2026-04-03 | Open |
+| Add fallback recovery section to @researcher agent file | @pslits | 2026-04-03 | Open |
+| Add fallback recovery section to @planner agent file | @pslits | 2026-04-03 | Open |
+| Add fallback recovery section to @implementer agent file | @pslits | 2026-04-03 | Open |
+
+---
+
+## Outcome (complete after execution)
+
+_To be filled after the change is made._

--- a/docs/adr/0006-instruction-drift-terminology.md
+++ b/docs/adr/0006-instruction-drift-terminology.md
@@ -1,0 +1,67 @@
+# ADR-0006: Introduce "Instruction Drift" Terminology Across Framework
+
+Date: 2026-03-20
+Status: Proposed
+HITL Issue: [#14](https://github.com/pslits/copilot-session-feedback/issues/14)
+Decider: @pslits
+Risk Tier: low
+
+---
+
+## Context
+
+The book's Ch. 6 identifies "instruction drift" as the central explainability problem in agentic
+systems: rules that were correct at time T become incorrect or misleading by time T+N as the
+codebase, team, or tooling evolves. The `/audit` prompt exists precisely to detect and remediate
+instruction drift — but neither the prompt nor the rule-writing instructions use this term.
+
+Without the term, the system's explainability story is incomplete. A reviewer or auditor who has
+read the book cannot map the `/audit` mechanism to the instruction drift problem it solves. The
+rule-writing checklist asks "Is it still true?" but frames it as a general quality check, not as
+drift detection.
+
+Using the terminology also helps future contributors understand *why* the monthly audit cadence
+exists: it is a scheduled drift-detection run, not general housekeeping.
+
+---
+
+## Decision
+
+> **We decide to introduce the term "instruction drift" explicitly in rule-writing.instructions.md
+> and in the /audit prompt description, naming the monthly cadence as a drift-detection cycle.**
+
+The change is additive: existing content is preserved; the term and its definition from the book
+(rules correct at T become incorrect by T+N due to codebase/team/tooling change) are inserted at
+appropriate points.
+
+---
+
+## Consequences
+
+### Positive
+- Framework language aligns with Ch. 6 of the book.
+- The purpose of the monthly audit is unambiguous.
+- Future contributors recognise the concept immediately if they have read the book.
+
+### Negative / Risks
+- None. Documentation-only change.
+
+### Neutral
+- The term "instruction drift" may surface questions about automated drift detection — this is
+  the aspirational Gap #13 and should be cross-referenced.
+
+---
+
+## Follow-up Actions
+
+| Action | Owner | Due Date | Status |
+|---|---|---|---|
+| Add "instruction drift" definition to rule-writing.instructions.md | @pslits | 2026-04-03 | Open |
+| Add "instruction drift" context to /audit prompt | @pslits | 2026-04-03 | Open |
+| Cross-reference ADR-0006 in Instruction Fidelity Auditing catalogue entry | @pslits | 2026-04-03 | Open |
+
+---
+
+## Outcome (complete after execution)
+
+_To be filled after the change is made._

--- a/docs/adr/0007-hook-script-timeout-strategy.md
+++ b/docs/adr/0007-hook-script-timeout-strategy.md
@@ -1,0 +1,76 @@
+# ADR-0007: Specify Hook Script Timeout and Soft-Fail Strategy
+
+Date: 2026-03-20
+Status: Proposed
+HITL Issue: [#15](https://github.com/pslits/copilot-session-feedback/issues/15)
+Decider: @pslits
+Risk Tier: medium
+
+---
+
+## Context
+
+The framework makes external calls from hook scripts: git operations (Stop hook), shell formatters
+(PostToolUse), and optionally curl (Notification hook). These are real failure surfaces. The book's
+Ch. 7 (Robustness and Fault Tolerance) notes that Circuit Breaker logic applies even without named
+external services — any external call that can hang or fail silently needs a timeout contract.
+
+Currently:
+- No maximum execution time is specified for any hook script.
+- A hanging `git` or `curl` call would block the VS Code agent indefinitely.
+- The hooks.instructions.md documents exit codes (0/2/other) but has no wall-clock budget.
+- The Notification hook's `curl` failure mode is completely undocumented.
+
+This is the framework's primary production reliability gap: a slow network or locked git index
+could hang the Stop hook and block session end.
+
+---
+
+## Decision
+
+> **We decide to specify a maximum execution time of 2000ms per hook script (hard limit), enforce
+> timeouts on all external calls within scripts, and document the soft-fail behaviour for each
+> hook when the timeout is exceeded.**
+
+Specific decisions:
+- All hook scripts must complete within 2000ms (measured from hook invocation to exit).
+- `curl` calls must use `--max-time 3 --connect-timeout 2`.
+- `git` operations that may block (e.g., waiting for remote) must be replaced with local-only
+  equivalents or wrapped with `timeout 2`.
+- Timeout expiry = exit code 2 (soft block) — the agent is informed but not hard-blocked.
+- This strategy is documented in hooks.instructions.md and in the Exception Handling catalogue entry.
+
+---
+
+## Consequences
+
+### Positive
+- Eliminates the hang risk from external calls in hooks.
+- Aligns the framework with Ch. 7 fault tolerance recommendations.
+- Provides a concrete, testable performance contract for all hook scripts.
+
+### Negative / Risks
+- 2000ms may be too tight on slow machines or for complex git operations. The threshold should
+  be validated in practice and adjusted. Starting value is a proposal, not a hard requirement.
+- Adding timeouts to shell scripts increases complexity slightly.
+
+### Neutral
+- The 2000ms budget applies to the entire script, not per-call. Multi-call scripts must budget
+  accordingly.
+
+---
+
+## Follow-up Actions
+
+| Action | Owner | Due Date | Status |
+|---|---|---|---|
+| Add timeout budget section to hooks.instructions.md | @pslits | 2026-04-03 | Open |
+| Add --max-time flags to Notification hook curl template | @pslits | 2026-04-03 | Open |
+| Wrap Stop hook git operation with timeout guard | @pslits | 2026-04-03 | Open |
+| Update Exception Handling catalogue entry with timeout strategy | @pslits | 2026-04-03 | Open |
+
+---
+
+## Outcome (complete after execution)
+
+_To be filled after the change is made._

--- a/docs/adr/0008-collaborative-copiloting-reclassification.md
+++ b/docs/adr/0008-collaborative-copiloting-reclassification.md
@@ -1,0 +1,68 @@
+# ADR-0008: Re-classify Collaborative Co-piloting as Primary Interaction Mode
+
+Date: 2026-03-20
+Status: Proposed
+HITL Issue: [#16](https://github.com/pslits/copilot-session-feedback/issues/16)
+Decider: @pslits
+Risk Tier: low
+
+---
+
+## Context
+
+The design document's pattern rejection table labels Collaborative Co-piloting (A&B, Tier 5) as
+"general model, not a design choice." This is a significant under-classification. The book's Ch. 8
+describes Collaborative Co-piloting as the mode where human and agent work simultaneously with the
+human retaining final authority — which is exactly the primary interaction mode of this system.
+
+The entire feedback loop exists *because* the developer is co-piloting with Copilot every day.
+The friction, corrections, and vocabulary gaps that feed the flywheel are all artefacts of the
+co-piloting experience. Misclassifying this as "not a design choice" makes the trigger context
+for the whole system invisible in the design document.
+
+Correcting this also sharpens the framing: the feedback loop is not a general improvement system —
+it is a co-piloting quality improvement system specifically. The success metrics and the human gates
+all derive from co-piloting context.
+
+---
+
+## Decision
+
+> **We decide to re-classify Collaborative Co-piloting from "rejected (general model)" to
+> "foundational context" in the design document, and to add a brief description of it as the
+> trigger interaction mode that justifies the entire feedback loop.**
+
+The pattern itself does not need to be added to the "Recommended Patterns" table — it is the
+environment, not a component of the pipeline. A dedicated paragraph in the System Summary section
+of the design document is the appropriate location.
+
+---
+
+## Consequences
+
+### Positive
+- The design rationale for the feedback loop is explicit and traceable to the book.
+- Future contributors immediately understand the interaction context without having to infer it.
+- Correct classification removes a potential point of confusion when reviewing the rejection table.
+
+### Negative / Risks
+- None. Documentation-only change.
+
+### Neutral
+- The framing change may prompt a discussion about whether the system is applicable to non-
+  co-piloting agent modes (autonomous agents). That is a valid future question.
+
+---
+
+## Follow-up Actions
+
+| Action | Owner | Due Date | Status |
+|---|---|---|---|
+| Update System Summary in design document | @pslits | 2026-04-03 | Open |
+| Update rejection table entry for Collaborative Co-piloting | @pslits | 2026-04-03 | Open |
+
+---
+
+## Outcome (complete after execution)
+
+_To be filled after the change is made._

--- a/docs/adr/0009-escalation-message-schema.md
+++ b/docs/adr/0009-escalation-message-schema.md
@@ -1,0 +1,75 @@
+# ADR-0009: Define Escalation Message Schema for Soft-Block (Exit Code 2)
+
+Date: 2026-03-20
+Status: Proposed
+HITL Issue: [#17](https://github.com/pslits/copilot-session-feedback/issues/17)
+Decider: @pslits
+Risk Tier: low
+
+---
+
+## Context
+
+The book's Ch. 8 (Human-Agent Interaction Patterns) — specifically the "Agent Calls Human (HITL
+Escalation)" pattern — stresses that the quality of the escalation message determines whether the
+human can make a useful decision. Poor escalation messages (e.g., "blocked" with no context) lead
+to human confusion rather than resolution.
+
+The framework implements soft-block escalation via PreToolUse hook exit code 2: the agent's
+intended action is paused and a message is shown to the developer. However, the security-patterns.json
+file defines the blocked patterns but does not specify the format of the message shown when a block
+triggers. Some current messages may be "Blocked: [pattern]" without a reason, an override path, or
+a recommended alternative.
+
+This means the developer is interrupted but not helped — they must infer why the block occurred and
+how to proceed, adding friction and potentially causing them to disable the hook entirely.
+
+---
+
+## Decision
+
+> **We decide to define and enforce a structured escalation message schema for all exit code 2
+> responses from hook scripts, and to update the security-patterns.json template and hooks
+> documentation accordingly.**
+
+Schema (3 mandatory fields):
+
+```
+BLOCKED: <action attempted in one line>
+REASON:  <why this action is protected — policy or risk>
+NEXT:    <what the developer should do instead, or how to override>
+```
+
+All PreToolUse soft-blocks must use this schema. The schema is documented in hooks.instructions.md.
+
+---
+
+## Consequences
+
+### Positive
+- Developer has actionable context when blocked, reducing friction.
+- Aligns with Ch. 8 escalation message quality requirements.
+- Override path is explicit, reducing the temptation to disable the hook entirely.
+
+### Negative / Risks
+- Existing security-patterns.json entries need message field updates — small but real effort.
+- If the message is too detailed, it may distract from the agent's primary task flow.
+
+### Neutral
+- The schema is line-oriented for easy parsing by both humans and future automation.
+
+---
+
+## Follow-up Actions
+
+| Action | Owner | Due Date | Status |
+|---|---|---|---|
+| Define schema in hooks.instructions.md | @pslits | 2026-04-03 | Open |
+| Update security-patterns.json entries to use schema | @pslits | 2026-04-03 | Open |
+| Add schema example to PreToolUse hook template | @pslits | 2026-04-03 | Open |
+
+---
+
+## Outcome (complete after execution)
+
+_To be filled after the change is made._

--- a/docs/adr/0010-fixed-procedures-vs-react.md
+++ b/docs/adr/0010-fixed-procedures-vs-react.md
@@ -1,0 +1,71 @@
+# ADR-0010: Document Why Fixed Procedures Outperform ReAct in This Context
+
+Date: 2026-03-20
+Status: Proposed
+HITL Issue: [#18](https://github.com/pslits/copilot-session-feedback/issues/18)
+Decider: @pslits
+Risk Tier: low
+
+---
+
+## Context
+
+The patterns catalogue correctly excludes ReAct (Reason + Act) for the framework's agents, stating
+"agents use fixed procedures." However, the rationale is missing from the entry and from the agent
+files themselves.
+
+The book's Ch. 9 provides the theoretical foundation for this tradeoff: ReAct agents are more
+adaptive but less predictable. In a feedback loop system where reproducibility and auditability
+are critical — each run must produce a comparable output so improvements can be measured against
+a baseline — fixed procedures are demonstrably superior to ReAct's open-ended reasoning loops.
+
+Without this explanation:
+- Future contributors may add ReAct-style open-ended reasoning to agent prompts, not realising
+  they are degrading the system's auditability.
+- The framework appears to reject ReAct arbitrarily rather than for principled reasons.
+- The tradeoff between adaptability and predictability is invisible.
+
+---
+
+## Decision
+
+> **We decide to add a "Design Rationale" note to the ReAct Agent catalogue entry and to the
+> agent files explaining why fixed-procedure agents are the correct choice in an auditable
+> feedback loop system, referencing the predictability-vs-adaptability tradeoff from Ch. 9.**
+
+The note will read: "Fixed procedures are preferred over ReAct in this system because the feedback
+loop requires reproducible, auditable outputs that can be compared across sessions. ReAct's dynamic
+reason-act loops introduce output variability that would make session-over-session improvement
+measurement unreliable. Adaptability is achieved through the feedback loop itself (weekly rule
+updates), not through per-invocation dynamic reasoning."
+
+---
+
+## Consequences
+
+### Positive
+- The rejection of ReAct is principled and traceable to Ch. 9.
+- Future contributors are warned against introducing open-ended reasoning.
+- Auditability as a first-class design goal is explicit.
+
+### Negative / Risks
+- None. Documentation-only change.
+
+### Neutral
+- Some tasks (e.g., complex codebase research) might genuinely benefit from ReAct. The note
+  should acknowledge this nuance while defending the current choice.
+
+---
+
+## Follow-up Actions
+
+| Action | Owner | Due Date | Status |
+|---|---|---|---|
+| Update ReAct Agent catalogue entry with design rationale | @pslits | 2026-04-03 | Open |
+| Add design rationale comment to @researcher agent file | @pslits | 2026-04-03 | Open |
+
+---
+
+## Outcome (complete after execution)
+
+_To be filled after the change is made._

--- a/docs/adr/0011-trace-id-threading.md
+++ b/docs/adr/0011-trace-id-threading.md
@@ -1,0 +1,89 @@
+# ADR-0011: Introduce Trace ID Threading Across Lifecycle Hook Events
+
+Date: 2026-03-20
+Status: Proposed
+HITL Issue: [#19](https://github.com/pslits/copilot-session-feedback/issues/19)
+Decider: @pslits
+Risk Tier: high
+
+---
+
+## Context
+
+The book's Ch. 10 (System-Level Patterns for Production Readiness) identifies the trace ID as the
+fundamental unit of observability in Lifecycle Callbacks / AgentOps: a single identifier that
+links every lifecycle event (SessionStart → PreToolUse → PostToolUse → ... → SessionEnd) into a
+reconstructable session trace.
+
+The framework's `sessions.jsonl` logs timestamps and session IDs but there is no evidence that the
+same trace ID is present in all hook events for a given session. Without it:
+- It is impossible to reconstruct "exactly what happened in session X" from the JSONL alone.
+- The Stop hook archives transcripts to a session directory but hook event records at non-Stop
+  events have no reference to the session they belong to.
+- Debugging "why did hook Y fire in session Z" requires manual timestamp correlation, which is
+  fragile.
+
+This is the highest-priority gap from the book review because it is a functional observability
+gap, not a framing issue. The Lifecycle Callbacks pattern is only partially implemented without
+cross-event trace correlation.
+
+Risk is classified **high** because adding a trace ID to all hooks requires coordinated changes
+across multiple hook scripts and the sessions.jsonl schema — a wider blast radius than any other
+gap fix.
+
+---
+
+## Decision
+
+> **We decide to introduce a session-scoped trace ID (UUID v4, generated at SessionStart) that is
+> written to a temporary session state file and read by all subsequent hooks in the same session,
+> and to extend the sessions.jsonl schema to include the trace_id field in every event record.**
+
+Implementation approach:
+1. SessionStart hook: generate `trace_id=$(uuidgen)`, write to `.session_trace` temp file.
+2. All other hooks that log to sessions.jsonl: read trace_id from `.session_trace` before writing.
+3. Stop hook: include trace_id in the archive directory name or metadata.json.
+4. SessionEnd hook: delete `.session_trace` and write final record with trace_id to sessions.jsonl.
+5. Document the `.session_trace` file lifecycle and the trace_id field in hooks.instructions.md.
+
+Fallback if `.session_trace` is missing: use `"trace_id": "unknown-<timestamp>"` to prevent parse
+failures while making the gap visible.
+
+---
+
+## Consequences
+
+### Positive
+- Full session reconstruction from sessions.jsonl becomes possible.
+- Debugging multi-hook failures is reduced from manual timestamp correlation to trace_id lookup.
+- Completes the Lifecycle Callbacks / AgentOps pattern implementation.
+- Aligns the framework with Ch. 10's observability requirements.
+
+### Negative / Risks
+- Requires coordinated changes to all hook scripts that write to sessions.jsonl.
+- The `.session_trace` temp file is a new external dependency for hook scripts; if SessionStart
+  hook fails, downstream hooks will fall back to "unknown" — acceptable but visible.
+- `uuidgen` may not be available on all platforms. Fallback: use `python -c "import uuid; print(uuid.uuid4())"`.
+
+### Neutral
+- The trace_id is a v4 UUID; it is not cryptographically signed and provides no security guarantees.
+  It is an observability tool only.
+
+---
+
+## Follow-up Actions
+
+| Action | Owner | Due Date | Status |
+|---|---|---|---|
+| Update SessionStart hook to generate and write trace_id | @pslits | 2026-04-03 | Open |
+| Update all hooks that write to sessions.jsonl to include trace_id | @pslits | 2026-04-03 | Open |
+| Update sessions.jsonl schema documentation | @pslits | 2026-04-03 | Open |
+| Update hooks.instructions.md with trace_id lifecycle | @pslits | 2026-04-03 | Open |
+| Add uuidgen fallback for cross-platform compatibility | @pslits | 2026-04-03 | Open |
+| Test full session trace reconstruction from sessions.jsonl | @pslits | 2026-04-10 | Open |
+
+---
+
+## Outcome (complete after execution)
+
+_To be filled after the change is made._

--- a/docs/adr/0012-registry-introduction-threshold.md
+++ b/docs/adr/0012-registry-introduction-threshold.md
@@ -1,0 +1,65 @@
+# ADR-0012: Document Registry Introduction Threshold
+
+Date: 2026-03-20
+Status: Proposed
+HITL Issue: [#20](https://github.com/pslits/copilot-session-feedback/issues/20)
+Decider: @pslits
+Risk Tier: low
+
+---
+
+## Context
+
+The book's Ch. 10 defines the Tool and Agent Registry pattern — a centralised catalogue of
+available agents and tools with schemas, versioning, and health status. The framework correctly
+excludes this as premature for a 3-agent, single-developer system. However, the catalogue entry
+does not document when the registry should be introduced.
+
+As the framework grows (more skills, more agents, team adoption), the absence of a documented
+threshold means the registry will either:
+(a) Never be introduced because no one knows when the trigger condition is met, or
+(b) Introduced too early, adding governance overhead before there is complexity to govern.
+
+Both outcomes are suboptimal. A simple size-based threshold prevents both failure modes.
+
+---
+
+## Decision
+
+> **We decide to add an explicit introduction threshold to the Tool and Agent Registry catalogue
+> entry: "Introduce when the system reaches 5+ active agents OR 10+ active skills, whichever
+> comes first."**
+
+This threshold is based on the book's Single Agent Baseline guidance: start simple, add
+orchestration only when justified by observable complexity. 5 agents / 10 skills represents the
+point at which discovery and governance overhead exceeds the cost of a registry.
+
+---
+
+## Consequences
+
+### Positive
+- The registry introduction decision is criteria-based rather than arbitrary.
+- Prevents premature governance overhead.
+- Provides an observable trigger for when to revisit this decision.
+
+### Negative / Risks
+- The threshold (5/10) is a heuristic, not a validated number. It should be treated as a
+  starting point for a future ADR when the threshold is approached.
+
+### Neutral
+- The threshold docs remain dormant until the system hits 4 agents or 9 skills.
+
+---
+
+## Follow-up Actions
+
+| Action | Owner | Due Date | Status |
+|---|---|---|---|
+| Add introduction threshold to Tool and Agent Registry entry | @pslits | 2026-04-03 | Open |
+
+---
+
+## Outcome (complete after execution)
+
+_To be filled after the change is made._

--- a/docs/adr/0013-automated-feedback-collection-aspiration.md
+++ b/docs/adr/0013-automated-feedback-collection-aspiration.md
@@ -1,0 +1,71 @@
+# ADR-0013: Explore Partial Automation of Feedback Collection (Aspirational)
+
+Date: 2026-03-20
+Status: Proposed
+HITL Issue: [#21](https://github.com/pslits/copilot-session-feedback/issues/21)
+Decider: @pslits
+Risk Tier: low
+
+---
+
+## Context
+
+The book's Ch. 11 (Advanced Adaptation: Building Agents That Learn) covers automated feedback
+collection — not just human-mediated capture. The framework's current feedback path is 100%
+human-initiated: a developer manually runs `/compact` or reviews a session to extract findings.
+
+Partial automation is possible within the existing VS Code-native constraint:
+- The Stop hook could auto-scan the session transcript for tool-call correction patterns
+  (user immediately follows a tool call with an edit — a common signal of agent error).
+- The PostCompact hook could compare which rules were active before compaction against which
+  corrections appeared in the session, tagging likely drift candidates.
+- The PreCompact hook could export a "rules-in-effect" snapshot that is later compared to the
+  post-session correction log.
+
+None of these require external infrastructure. However, they represent Level 4–5 maturity work
+and should be deferred until the current manual loop is validated and stable. This ADR documents
+the aspiration for the adoption roadmap's Ongoing phase.
+
+---
+
+## Decision
+
+> **We decide to document automated feedback collection as an aspirational capability in the
+> adoption roadmap's Ongoing phase, with a prerequisite of at least 8 weeks of stable manual
+> loop operation before any automation is introduced.**
+
+No implementation work is approved at this time. This ADR is a planning record that:
+1. Names the automation options that are within the VS Code-native constraint.
+2. Sets a stability prerequisite to prevent premature automation.
+3. Links the aspiration to Ch. 11 of the book for future reference.
+
+---
+
+## Consequences
+
+### Positive
+- The aspirational roadmap is visible; contributors know where the flywheel evolution leads.
+- The stability prerequisite prevents automation being introduced before the manual loop is
+  mature enough to generate reliable training signal.
+
+### Negative / Risks
+- None. This ADR approves only documentation, not implementation.
+
+### Neutral
+- When the prerequisite is met, a new ADR will be required to approve the specific automation
+  approach.
+
+---
+
+## Follow-up Actions
+
+| Action | Owner | Due Date | Status |
+|---|---|---|---|
+| Add automated feedback collection entry to adoption roadmap Ongoing phase | @pslits | 2026-04-03 | Open |
+| Note stability prerequisite (8 weeks manual loop) in the entry | @pslits | 2026-04-03 | Open |
+
+---
+
+## Outcome (complete after execution)
+
+_To be filled after the change is made._

--- a/docs/adr/0014-criteria-based-adoption-roadmap.md
+++ b/docs/adr/0014-criteria-based-adoption-roadmap.md
@@ -1,0 +1,81 @@
+# ADR-0014: Convert Adoption Roadmap from Time-Based to Criteria-Based Phases
+
+Date: 2026-03-20
+Status: Proposed
+HITL Issue: [#22](https://github.com/pslits/copilot-session-feedback/issues/22)
+Decider: @pslits
+Risk Tier: medium
+
+---
+
+## Context
+
+The book's Ch. 12 (A Practical Roadmap: Implementing Agentic Patterns by Maturity Level) uses
+observable capability thresholds per maturity level, not calendar time, to gate progression. The
+framework's adoption roadmap in adoption-roadmap.instructions.md currently uses weeks ("Week 1",
+"Week 2", "Week 4") as phase delimiters.
+
+The problem with time-based phases:
+- A developer who completes Week 1 in 3 days gains no signal to advance to Week 2.
+- A developer who is blocked for 3 weeks on Week 1 has no criterion to recognise the blockage.
+- Teams adopting the framework at different times cannot coordinate using calendar references.
+
+Criteria-based phases (e.g., "advance to Phase 2 when: at least 2 sessions have produced rule
+commits AND the `/verify` prompt passes without errors") are independently measurable by any
+developer at any start date.
+
+Time references can be kept as *guidance* ("typically 1–2 weeks") but must not be the gate.
+
+---
+
+## Decision
+
+> **We decide to convert the adoption-roadmap.instructions.md phases from time-gated to
+> criteria-gated, adding at least one observable success threshold per phase that must be met
+> before proceeding to the next phase. Time estimates are retained as guidance in parentheses.**
+
+Proposed phase thresholds (to be validated):
+- **Phase 1 complete:** `/verify` prompt passes in a live session AND at least one rule has been
+  committed from a session finding.
+- **Phase 2 complete:** Stop hook is operational (exit 0 on session end) AND at least one hook
+  event is logged to sessions.jsonl.
+- **Phase 3 complete:** RPI chain has been used end-to-end at least once AND a planner-produced
+  plan has been executed successfully by @implementer.
+- **Ongoing threshold:** Corrections per session trending downward over 4 consecutive sessions.
+
+---
+
+## Consequences
+
+### Positive
+- Progression is independently verifiable by any developer.
+- Blocked phases are detectable: if criteria are unmet after 3× the typical time estimate, it
+  signals a setup problem.
+- Aligns the roadmap with Ch. 12's maturity-level capability thresholds.
+- Works for teams with different start dates.
+
+### Negative / Risks
+- Converting the existing roadmap requires rewriting the phase headers and adding criteria
+  sections — moderate effort.
+- The proposed thresholds are initial estimates; they may need adjustment based on real-world
+  adoption experience. Version the criteria in the file.
+
+### Neutral
+- Time estimates remain as guidance; removing them entirely would lose useful planning context.
+
+---
+
+## Follow-up Actions
+
+| Action | Owner | Due Date | Status |
+|---|---|---|---|
+| Rewrite adoption-roadmap.instructions.md phase gates to criteria-based | @pslits | 2026-04-10 | Open |
+| Add time estimates as parenthetical guidance | @pslits | 2026-04-10 | Open |
+| Validate proposed thresholds against actual adoption experience | @pslits | 2026-05-01 | Open |
+| Cross-reference ADR-0014 in the roadmap file | @pslits | 2026-04-10 | Open |
+
+---
+
+## Outcome (complete after execution)
+
+_To be filled after the change is made._

--- a/docs/adr/0015-adk-vscode-hook-equivalence.md
+++ b/docs/adr/0015-adk-vscode-hook-equivalence.md
@@ -1,0 +1,79 @@
+# ADR-0015: Document ADK-to-VS Code Hook Equivalence
+
+Date: 2026-03-20
+Status: Proposed
+HITL Issue: [#23](https://github.com/pslits/copilot-session-feedback/issues/23)
+Decider: @pslits
+Risk Tier: low
+
+---
+
+## Context
+
+The book's Chs. 13–15 provide reference implementations using Google's Agent Development Kit
+(ADK), LangGraph, and CrewAI. All code examples in the companion GitHub repository
+(PacktPublishing/Agentic-Architectural-Patterns-for-Building-Multi-Agent-Systems) use ADK as the
+primary framework.
+
+ADK's lifecycle callbacks (on_agent_start, on_tool_call, on_tool_response, on_agent_end) are the
+direct equivalent of VS Code's hook events (SessionStart, PreToolUse, PostToolUse, SessionEnd).
+However, nowhere in the `agentic-patterns` skill or catalogue is this equivalence stated.
+
+A developer who has read the book and wants to apply the ADK examples to this framework has no
+mapping table. They may conclude the framework is unrelated to the book's code examples, missing
+the direct structural parallel.
+
+Similarly, the book's ADK event payloads (which include trace IDs — connecting to ADR-0011) differ
+in schema from VS Code hook stdin JSON. Documenting the mapping clarifies both the similarities
+and the divergences.
+
+---
+
+## Decision
+
+> **We decide to add an equivalence table to the Lifecycle Callbacks / AgentOps catalogue entry
+> mapping ADK lifecycle events to VS Code hook events, and noting schema differences (particularly
+> the trace ID gap addressed by ADR-0011).**
+
+Equivalence mapping:
+
+| ADK Event | VS Code Hook | Notes |
+|---|---|---|
+| on_agent_start | SessionStart | ADK includes trace_id; VS Code does not (see ADR-0011) |
+| on_tool_call | PreToolUse | ADK has typed tool schema; VS Code uses stdin JSON |
+| on_tool_response | PostToolUse | Similar structure |
+| on_agent_end | SessionEnd / Stop | VS Code has two variants; ADK has one |
+| on_compact / on_context_compress | PreCompact / PostCompact | VS Code-specific; no ADK equivalent |
+
+---
+
+## Consequences
+
+### Positive
+- Developers familiar with ADK can immediately map their knowledge to the VS Code framework.
+- The trace ID gap (ADR-0011) is contextualised against ADK's native trace support.
+- The catalogue becomes a useful bridge document, not just a reference sheet.
+
+### Negative / Risks
+- ADK evolves; the equivalence table may become stale. Add a "verified against ADK version X"
+  note and a review trigger in the monthly audit.
+
+### Neutral
+- LangGraph and CrewAI equivalences are not in scope for this ADR — they can be added in a
+  follow-up if the framework is used alongside those tools.
+
+---
+
+## Follow-up Actions
+
+| Action | Owner | Due Date | Status |
+|---|---|---|---|
+| Add equivalence table to Lifecycle Callbacks catalogue entry | @pslits | 2026-04-03 | Open |
+| Note ADK version the table was verified against | @pslits | 2026-04-03 | Open |
+| Add review trigger for the equivalence table to monthly audit prompt | @pslits | 2026-04-03 | Open |
+
+---
+
+## Outcome (complete after execution)
+
+_To be filled after the change is made._


### PR DESCRIPTION
Create 15 Architecture Decision Records covering all gaps identified during the framework review against 'Agentic Architectural Patterns for Building Multi-Agent Systems' (Packt, 2026).

Each ADR is linked to a corresponding HITL GitHub issue (#9–#23) and follows the approved schema: context, decision, consequences, follow-up actions, and outcome placeholder.

ADRs span three risk tiers:
- Low (documentation/framing gaps): 0001–0002, 0004, 0006, 0008, 0009, 0010, 0012, 0013, 0015
- Medium (structural/process gaps): 0003, 0005, 0007, 0014
- High (functional observability gap): 0011 (trace ID threading)

Only ADR-0011 (#19) is approved for immediate execution.

Refs #9 #10 #11 #12 #13 #14 #15 #16 #17 #18 #19 #20 #21 #22 #23